### PR TITLE
Update config.rs

### DIFF
--- a/src/build/config.rs
+++ b/src/build/config.rs
@@ -67,7 +67,6 @@ impl Default for BuildConfig {
                         "-(+".to_string(),
                         "-\\+".to_string(),
                         "-Z+".to_string(),
-                        "-O2".to_string(),
                     ],
                 }),
             },


### PR DESCRIPTION
I inspected that '-d3' cannot be combined with '-O2'. Moreover, '-d3' itself defines '-O0'.
https://github.com/pawn-lang/compiler/wiki/Options#-dn 
"  -d3 - same as -d2 but also disables optimization (implies -O0) "
https://github.com/pawn-lang/compiler/blob/master/source/compiler/sc1.c#L1076
```c
switch (*option_value(ptr)) {
        case '0':
          sc_debug=0;
          break;
        case '1':
          sc_debug=sCHKBOUNDS; 
          break;
        case '2':
          sc_debug=sCHKBOUNDS | sSYMBOLIC;
          break;
        case '3':
          sc_debug=sCHKBOUNDS | sSYMBOLIC;
          pc_optimize=sOPTIMIZE_NONE; // set optimization to none (-O0)
          /* also avoid peephole optimization */
          break;
        default:
          about();
        } /* switch */
```